### PR TITLE
update oauth client id creation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The first time you run `gdcp` a new directory `~/.gdcp/` will be created and you
 - Create a new project and select it
 - Under 'APIs' make sure the 'Drive API' is turned on
 - Under 'Credentials' create a new OAuth client ID
-  Choose 'Installed -> Other' for application type
+  Choose 'Desktop app' for application type
 - Click 'Download JSON' to download the secrets file
 - Copy the secrets file to ~/.gdcp/client_secrets.json
 ```

--- a/gdcp
+++ b/gdcp
@@ -820,7 +820,7 @@ def create_configdir(location=None):
         msg.append("- Create a new project and select it")
         msg.append("- Under 'APIs' make sure the 'Drive API' is turned on")
         msg.append("- Under 'Credentials' create a new OAuth client ID")
-        msg.append("  Choose 'Installed -> Other' for application type")
+        msg.append("  Choose 'Desktop app' for application type")
         msg.append("- Click 'Download JSON' to download the secrets file")
         msg.append("- Copy the secrets file to %s" % client_secrets)
         error("\n".join(msg))


### PR DESCRIPTION
The 'Installed -> Other' option is no longer available when creating a new OAuth client
![Screenshot from 2021-01-18 15-15-19](https://user-images.githubusercontent.com/10558897/104971382-7a388d80-59a3-11eb-84af-9a1b8e408ed5.png)

Based on a similar issue [here](https://github.com/metabase/metabase/issues/12491), as well as an issue getting to the authentication URL using a different application type, Desktop App seems to be the best alternate choice.